### PR TITLE
update deps for fibers and make-sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "cake test"
   },
   "dependencies": {
-    "make-sync": "git://github.com/dnice-asana/node-make-sync.git#master",
+    "make-sync": "git://github.com/asana/node-make-sync.git#master",
     "fibers": "^5.0.0",
     "wd": "~0.2.7",
     "lodash": "~2.2.1"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "cake test"
   },
   "dependencies": {
-    "make-sync": "~0.2.0",
+    "make-sync": "git://github.com/dnice-asana/node-make-sync.git#master",
     "fibers": "^5.0.0",
     "wd": "~0.2.7",
     "lodash": "~2.2.1"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "make-sync": "~0.2.0",
-    "fibers": "~1.0.1",
+    "fibers": "^5.0.0",
     "wd": "~0.2.7",
     "lodash": "~2.2.1"
   },


### PR DESCRIPTION
Updating node-make-sync to use fibers v5 so node12 can run it. This will be referenced in an upcoming change to node12/package.json, and be checked into codez (after being built in vagrant) underneath node12/node_modules

The modules make-sync also relies on fibers v1, so I forked that repo and have us pull from the fork that relies on fibers v5